### PR TITLE
TDDed update to loader.load to return the provided CFC.

### DIFF
--- a/loader.cfc
+++ b/loader.cfc
@@ -71,7 +71,7 @@ component accessors=true {
 	/**
 	* @hint loads a provided component with provided data
 	**/
-	public void function load(
+	public component function load(
 		required component cfc,
 		required struct data = {}
 	) {
@@ -79,6 +79,7 @@ component accessors=true {
 			cfc = arguments.cfc,
 			data = arguments.data
 		);
+		return arguments.cfc;
 	}
 
 	/**

--- a/test_loader.cfc
+++ b/test_loader.cfc
@@ -249,7 +249,8 @@ component extends="mxunit.framework.TestCase" {
 							"cfc": SerializeJson(new test_cfcs.Option().setId(1)),
 							"data": {name: "Option 1"}
 						}
-					}
+					},
+					"returnType": "test_cfcs.Option"
 				}
 			},
 			"test Widget (2)": {
@@ -266,7 +267,8 @@ component extends="mxunit.framework.TestCase" {
 							"cfc": SerializeJson(new test_cfcs.Widget().setId(2)),
 							"data": {name: "Widget 2"}
 						}
-					}
+					},
+					"returnType": "test_cfcs.Widget"
 				}
 			}
 		];
@@ -296,6 +298,7 @@ component extends="mxunit.framework.TestCase" {
 			// check assertions
 			calls["getCfcLoader"] = variables.loader["getCfcLoader_Args"];
 			AssertEquals(test.expect.calls, calls, "#name# - calls don't match expected");
+			AssertEquals(test.expect.returnType, GetMetaData(result).name, "#name# - return type doesn't match expected");
 		}
 	}
 


### PR DESCRIPTION
This should fix #1.

Updated tests to expect return type to be the CFC passed in. Updated loader.load return type and returned arguments.cfc.