### PR TITLE
(fixes #4) updated loader to cache itself (sometimes)

### DIFF
--- a/generator.cfc
+++ b/generator.cfc
@@ -7,6 +7,9 @@ component {
 		var properties = getProperties(cfc = arguments.cfc);
 		var code =  'component {
 
+			// name of component this loader loads
+			variables.componentToLoad = "#GetMetaData(arguments.cfc).name#";
+
 			// Cached loaders (populated in constructor)
 			variables.loaders = {};
 
@@ -16,8 +19,13 @@ component {
 
 			public component function init(required loader loader) {
 				variables.loader = arguments.loader;
+				// micro-optimization: pre-cache a loader for each template VO
 				for ( var key in variables.vos ) {
-					variables.loaders[key] = variables.loader.getCfcLoader(variables.vos[key]);
+					if ( key == variables.componentToLoad ) {
+						variables.loaders[key] = this;
+					} else {
+						variables.loaders[key] = variables.loader.getCfcLoader(variables.vos[key]);
+					}
 				}
 				return this;
 			}

--- a/test_generator.cfc
+++ b/test_generator.cfc
@@ -52,6 +52,9 @@ component extends="mxunit.framework.TestCase" {
 					"result": '
 						component {
 
+							// name of component this loader loads
+							variables.componentToLoad = "test_cfcs.Option";
+
 							// Cached loaders (populated in constructor)
 							variables.loaders = {};
 
@@ -61,8 +64,13 @@ component extends="mxunit.framework.TestCase" {
 
 							public component function init(required loader loader) {
 								variables.loader = arguments.loader;
+								// micro-optimization: pre-cache a loader for each template VO
 								for ( var key in variables.vos ) {
-									variables.loaders[key] = variables.loader.getCfcLoader(variables.vos[key]);
+									if ( key == variables.componentToLoad ) {
+										variables.loaders[key] = this;
+									} else {
+										variables.loaders[key] = variables.loader.getCfcLoader(variables.vos[key]);
+									}
 								}
 								return this;
 							}
@@ -109,6 +117,9 @@ component extends="mxunit.framework.TestCase" {
 					"result": '
 						component {
 
+							// name of component this loader loads
+							variables.componentToLoad = "test_cfcs.Option";
+
 							// Cached loaders (populated in constructor)
 							variables.loaders = {};
 
@@ -118,8 +129,13 @@ component extends="mxunit.framework.TestCase" {
 
 							public component function init(required loader loader) {
 								variables.loader = arguments.loader;
+								// micro-optimization: pre-cache a loader for each template VO
 								for ( var key in variables.vos ) {
-									variables.loaders[key] = variables.loader.getCfcLoader(variables.vos[key]);
+									if ( key == variables.componentToLoad ) {
+										variables.loaders[key] = this;
+									} else {
+										variables.loaders[key] = variables.loader.getCfcLoader(variables.vos[key]);
+									}
 								}
 								return this;
 							}


### PR DESCRIPTION
Updated generator to generate code that caches the component itself if a CFC has a property that is of its own type. (e.g. Person.cfc has a property of "mentor" that is of type "Person")

Should fix #4 