### PR TITLE
Load items already of item type

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,13 @@ Create an instance of the loader and set the LoadersPath.
 
 Get a handle on the loader and use it to load a CFC with data.
 
+	// long form
 	var response = new com.foo.bar();
 	loader.load(response, data);
 	return response;
+
+	// short form
+	return loader.load(new com.foo.bar(), data);
 
 That's really it. The loader will handle generating and caching loaders.
 Loaders are generated for each component with a name containing a "signature" hash.

--- a/generator.cfc
+++ b/generator.cfc
@@ -109,7 +109,7 @@ component {
 				if ( StructKeyExists(arguments.data, "#arguments.property.name#") && !IsNull(arguments.data["#arguments.property.name#"]) && IsArray(arguments.data["#arguments.property.name#"]) ) {
 					var clean = [];
 					for ( var item in arguments.data["#arguments.property.name#"] ) {
-						if ( IsStruct(item) ) {
+						if ( IsStruct(item) && !IsObject(item) ) {
 							var vo = Duplicate(variables.vos["#arguments.property.item_type#"]);
 							variables.loaders["#arguments.property.item_type#"].load(cfc = vo, data = item);
 							ArrayAppend(clean, vo);
@@ -124,7 +124,7 @@ component {
 		if ( arguments.property.type == "component" ) {
 			return '
 				if ( StructKeyExists(arguments.data, "#arguments.property.name#") && !IsNull(arguments.data["#arguments.property.name#"]) ) {
-					if ( IsStruct(arguments.data["#arguments.property.name#"]) ) {
+					if ( IsStruct(arguments.data["#arguments.property.name#"]) && !IsObject(arguments.data["#arguments.property.name#"]) ) {
 						var vo = Duplicate(variables.vos["#arguments.property.item_type#"]);
 						variables.loaders["#arguments.property.item_type#"].load(cfc = vo, data = arguments.data["#arguments.property.name#"]);
 						arguments.cfc.set#arguments.property.name#(vo);

--- a/test_cfcs/Widget.cfc
+++ b/test_cfcs/Widget.cfc
@@ -1,5 +1,5 @@
 component accessors=true {
 	property name="id" type="numeric";
 	property name="name" type="string";
-	property name="options" type="array" item_type="com.github.cfchris.cfc_loader.test_cfcs.Option";
+	property name="options" type="array" item_type="test_cfcs.Option";
 }

--- a/test_generator.cfc
+++ b/test_generator.cfc
@@ -371,7 +371,7 @@ component extends="mxunit.framework.TestCase" {
 				},
 				"expect": '
 					if ( StructKeyExists(arguments.data, "optionProp") && !IsNull(arguments.data["optionProp"]) ) {
-						if ( IsStruct(arguments.data["optionProp"]) ) {
+						if ( IsStruct(arguments.data["optionProp"]) && !IsObject(arguments.data["optionProp"]) ) {
 							var vo = Duplicate(variables.vos["test_cfcs.Option"]);
 							variables.loaders["test_cfcs.Option"].load(cfc = vo, data = arguments.data["optionProp"]);
 							arguments.cfc.setoptionProp(vo);
@@ -391,7 +391,7 @@ component extends="mxunit.framework.TestCase" {
 					if ( StructKeyExists(arguments.data, "optionsProp") && !IsNull(arguments.data["optionsProp"]) && IsArray(arguments.data["optionsProp"]) ) {
 						var clean = [];
 						for ( var item in arguments.data["optionsProp"] ) {
-							if ( IsStruct(item) ) {
+							if ( IsStruct(item) && !IsObject(item) ) {
 								var vo = Duplicate(variables.vos["test_cfcs.Option"]);
 								variables.loaders["test_cfcs.Option"].load(cfc = vo, data = item);
 								ArrayAppend(clean, vo);

--- a/test_loader.cfc
+++ b/test_loader.cfc
@@ -231,6 +231,74 @@ component extends="mxunit.framework.TestCase" {
 	}
 
 	/**
+	* @hint "I test load (with generation)."
+	**/
+	public void function test_load_integration() {
+		var tests = [
+			"test Widget (data is just structs/arrays)": {
+				"args": {
+					"cfc": new test_cfcs.Widget(),
+					"data": {
+						"id": 1,
+						"name": "structs/arrays",
+						"options": [
+							{"id": 1, "name": "Option 1"},
+							{"id": 2, "name": "Option 2"}
+						]
+					}
+				},
+				"expect": {
+					"returnType": "test_cfcs.Widget",
+					"serialized": {
+						"id": 1,
+						"name": "structs/arrays",
+						"options": [
+							{"id": 1, "name": "Option 1"},
+							{"id": 2, "name": "Option 2"}
+						]
+					}
+				}
+			},
+			"test Widget (data has items of item_type)": {
+				"args": {
+					"cfc": new test_cfcs.Widget(),
+					"data": {
+						"id": 2,
+						"name": "items of item_type",
+						"options": [
+							new test_cfcs.Option().setId(3).setName("Option 3"),
+							new test_cfcs.Option().setId(4).setName("Option 4")
+						]
+					}
+				},
+				"expect": {
+					"returnType": "test_cfcs.Widget",
+					"serialized": {
+						"id": 2,
+						"name": "items of item_type",
+						"options": [
+							{"id": 3, "name": "Option 3"},
+							{"id": 4, "name": "Option 4"}
+						]
+					}
+				}
+			}
+		];
+		for ( var name in tests ) {
+			var test = tests[name];
+			// call method under test
+			var result = variables.loader.load(cfc = test.args.cfc, data = test.args.data);
+			// check assertions
+			AssertEquals(test.expect.returnType, GetMetaData(result).name, "#name# - return type doesn't match expected");
+			AssertEquals(
+				test.expect.serialized,
+				DeserializeJson(SerializeJson(result)),
+				"#name# - result did not contain expected data"
+			);
+		}
+	}
+
+	/**
 	* @hint "I test load."
 	**/
 	public void function test_load() {


### PR DESCRIPTION
(should fix #6)

Also added the first "integration" test that generates loaders and uses them (instead of mocking them to track arguments, etc).