### PR TITLE
Fix loading race condition

### DIFF
--- a/generator.cfc
+++ b/generator.cfc
@@ -10,24 +10,23 @@ component {
 			// name of component this loader loads
 			variables.componentToLoad = "#GetMetaData(arguments.cfc).name#";
 
-			// Cached loaders (populated in constructor)
+			// cache of loaders (lazy loaded by getCfcLoader)
 			variables.loaders = {};
 
-			// Template VOs
+			// cache of template VOs (for duplicateing)
 			variables.vos = {};
 			#Trim(getVoCacheCode(properties = properties))#
 
 			public component function init(required loader loader) {
-				variables.loader = arguments.loader;
-				// micro-optimization: pre-cache a loader for each template VO
-				for ( var key in variables.vos ) {
-					if ( key == variables.componentToLoad ) {
-						variables.loaders[key] = this;
-					} else {
-						variables.loaders[key] = variables.loader.getCfcLoader(variables.vos[key]);
-					}
-				}
+				variables.parentLoader = arguments.loader;
 				return this;
+			}
+
+			private component function getCfcLoader(required string cfcName) {
+				if ( !StructKeyExists(variables.loaders, arguments.cfcName) ) {
+					variables.loaders[arguments.cfcName] = variables.parentLoader.getCfcLoader(variables.vos[arguments.cfcName]);
+				}
+				return variables.loaders[arguments.cfcName];
 			}
 
 			#Trim(getLoadMethod(properties = properties))#
@@ -100,18 +99,19 @@ component {
 	**/
 	private string function getPropertyCode(required struct property) {
 		// NOTE:
-		// 	"component" and "array" of "item_type" check if the data needs to be "load()ed" by using IsStruct().
-		// 	(The "assumption" being that if the data is a struct we can load it into "item_type".)
+		// 	properties w/ "item_type" check (IsStruct() && !IsObject()) to see if data needs to be "load()ed".
+		// 	(The "assumption" being that if data is a struct (and not an object) it can be loaded into "item_type".)
 		// 	I was doing the opposite using IsInstanceOf() to see it we "didn't need to load()" items.
 		// 	But, IsInstanceOf was like 100 times slower than IsStruct(). It's just too slow.
 		if ( arguments.property.type == "array" && arguments.property.item_type != "" ) {
 			return '
 				if ( StructKeyExists(arguments.data, "#arguments.property.name#") && !IsNull(arguments.data["#arguments.property.name#"]) && IsArray(arguments.data["#arguments.property.name#"]) ) {
 					var clean = [];
+					var loader = getCfcLoader("#arguments.property.item_type#");
 					for ( var item in arguments.data["#arguments.property.name#"] ) {
 						if ( IsStruct(item) && !IsObject(item) ) {
 							var vo = Duplicate(variables.vos["#arguments.property.item_type#"]);
-							variables.loaders["#arguments.property.item_type#"].load(cfc = vo, data = item);
+							loader.load(cfc = vo, data = item);
 							ArrayAppend(clean, vo);
 						} else {
 							ArrayAppend(clean, item);
@@ -126,7 +126,7 @@ component {
 				if ( StructKeyExists(arguments.data, "#arguments.property.name#") && !IsNull(arguments.data["#arguments.property.name#"]) ) {
 					if ( IsStruct(arguments.data["#arguments.property.name#"]) && !IsObject(arguments.data["#arguments.property.name#"]) ) {
 						var vo = Duplicate(variables.vos["#arguments.property.item_type#"]);
-						variables.loaders["#arguments.property.item_type#"].load(cfc = vo, data = arguments.data["#arguments.property.name#"]);
+						getCfcLoader("#arguments.property.item_type#").load(cfc = vo, data = arguments.data["#arguments.property.name#"]);
 						arguments.cfc.set#arguments.property.name#(vo);
 					} else {
 						arguments.cfc.set#arguments.property.name#(arguments.data["#arguments.property.name#"]);

--- a/loader.cfc
+++ b/loader.cfc
@@ -35,12 +35,7 @@ component accessors=true {
 					code = fixNewLine(getGenerator().generate(cfc = arguments.cfc))
 				);
 			}
-			// some CFCs have references to types that contain references back to the CFC
-			// so, load the loader into the cache immediately (without calling constructor)
-			variables.loaderCache[cfcName] = CreateObject("component", loaderName);
-			// now that it's in the cache and we can prevent racing circular dependencies,
-			// call the constructor to finish loading
-			variables.loaderCache[cfcName].init(loader = this);
+			variables.loaderCache[cfcName] = CreateObject("component", loaderName).init(loader = this);
 		}
 		return variables.loaderCache[cfcName];
 	}

--- a/test_generator.cfc
+++ b/test_generator.cfc
@@ -55,24 +55,23 @@ component extends="mxunit.framework.TestCase" {
 							// name of component this loader loads
 							variables.componentToLoad = "test_cfcs.Option";
 
-							// Cached loaders (populated in constructor)
+							// cache of loaders (lazy loaded by getCfcLoader)
 							variables.loaders = {};
 
-							// Template VOs
+							// cache of template VOs (for duplicateing)
 							variables.vos = {};
 							// VO cache code 1
 
 							public component function init(required loader loader) {
-								variables.loader = arguments.loader;
-								// micro-optimization: pre-cache a loader for each template VO
-								for ( var key in variables.vos ) {
-									if ( key == variables.componentToLoad ) {
-										variables.loaders[key] = this;
-									} else {
-										variables.loaders[key] = variables.loader.getCfcLoader(variables.vos[key]);
-									}
-								}
+								variables.parentLoader = arguments.loader;
 								return this;
+							}
+
+							private component function getCfcLoader(required string cfcName) {
+								if ( !StructKeyExists(variables.loaders, arguments.cfcName) ) {
+									variables.loaders[arguments.cfcName] = variables.parentLoader.getCfcLoader(variables.vos[arguments.cfcName]);
+								}
+								return variables.loaders[arguments.cfcName];
 							}
 
 							// load method 1
@@ -120,24 +119,23 @@ component extends="mxunit.framework.TestCase" {
 							// name of component this loader loads
 							variables.componentToLoad = "test_cfcs.Option";
 
-							// Cached loaders (populated in constructor)
+							// cache of loaders (lazy loaded by getCfcLoader)
 							variables.loaders = {};
 
-							// Template VOs
+							// cache of template VOs (for duplicateing)
 							variables.vos = {};
 							// VO cache code 2
 
 							public component function init(required loader loader) {
-								variables.loader = arguments.loader;
-								// micro-optimization: pre-cache a loader for each template VO
-								for ( var key in variables.vos ) {
-									if ( key == variables.componentToLoad ) {
-										variables.loaders[key] = this;
-									} else {
-										variables.loaders[key] = variables.loader.getCfcLoader(variables.vos[key]);
-									}
-								}
+								variables.parentLoader = arguments.loader;
 								return this;
+							}
+
+							private component function getCfcLoader(required string cfcName) {
+								if ( !StructKeyExists(variables.loaders, arguments.cfcName) ) {
+									variables.loaders[arguments.cfcName] = variables.parentLoader.getCfcLoader(variables.vos[arguments.cfcName]);
+								}
+								return variables.loaders[arguments.cfcName];
 							}
 
 							// load method 2
@@ -373,7 +371,7 @@ component extends="mxunit.framework.TestCase" {
 					if ( StructKeyExists(arguments.data, "optionProp") && !IsNull(arguments.data["optionProp"]) ) {
 						if ( IsStruct(arguments.data["optionProp"]) && !IsObject(arguments.data["optionProp"]) ) {
 							var vo = Duplicate(variables.vos["test_cfcs.Option"]);
-							variables.loaders["test_cfcs.Option"].load(cfc = vo, data = arguments.data["optionProp"]);
+							getCfcLoader("test_cfcs.Option").load(cfc = vo, data = arguments.data["optionProp"]);
 							arguments.cfc.setoptionProp(vo);
 						} else {
 							arguments.cfc.setoptionProp(arguments.data["optionProp"]);
@@ -390,10 +388,11 @@ component extends="mxunit.framework.TestCase" {
 				"expect": '
 					if ( StructKeyExists(arguments.data, "optionsProp") && !IsNull(arguments.data["optionsProp"]) && IsArray(arguments.data["optionsProp"]) ) {
 						var clean = [];
+						var loader = getCfcLoader("test_cfcs.Option");
 						for ( var item in arguments.data["optionsProp"] ) {
 							if ( IsStruct(item) && !IsObject(item) ) {
 								var vo = Duplicate(variables.vos["test_cfcs.Option"]);
-								variables.loaders["test_cfcs.Option"].load(cfc = vo, data = item);
+								loader.load(cfc = vo, data = item);
 								ArrayAppend(clean, vo);
 							} else {
 								ArrayAppend(clean, item);

--- a/test_loader.cfc
+++ b/test_loader.cfc
@@ -291,9 +291,9 @@ component extends="mxunit.framework.TestCase" {
 		);
 		// "baseline" stats from 2019-01-23
 		var baseline = [
-			"elapsed ms": 150,
+			"elapsed ms": 200,
 			"loop count": 1000,
-			"avg load() ms": 0.15
+			"avg load() ms": 0.20
 		];
 		// stats for the current run
 		var stats = [

--- a/test_loader.cfc
+++ b/test_loader.cfc
@@ -231,6 +231,89 @@ component extends="mxunit.framework.TestCase" {
 	}
 
 	/**
+	* @hint "I test load (for speed)."
+	**/
+	public void function test_load_benchmark() {
+		// NOTE
+		// This test could fail (be too slow) on different hardware/OS/etc combinations.
+		// I'm aware of this.
+		// I'll adjust this as necessary.
+		var data = {
+			"id": 1,
+			"name": "Benchmark Bundle",
+			"widgets": [
+				{
+					"id": 1,
+					"name": "Benchmark Widget 1",
+					"options": [
+						{"id": 1, "name": "Benchmark Option 1"},
+						{"id": 2, "name": "Benchmark Option 2"}
+					],
+					"isInBundles": [
+						{"id": 1, "Name": "Benchmark Bundle"},
+						{"id": 7, "Name": "Some Other Bundle"}
+					]
+				},
+				{
+					"id": 2,
+					"name": "Benchmark Widget 2",
+					"options": [
+						{"id": 3, "name": "Benchmark Option 3"},
+						{"id": 4, "name": "Benchmark Option 4"}
+					],
+					"isInBundles": [
+						{"id": 1,  "Name": "Benchmark Bundle"},
+						{"id": 42, "Name": "Yet Another Bundle"}
+					]
+				}
+			]
+		};
+		var loopCount = 1000;
+		// note the time
+		var startTime = GetTickCount();
+		// make sure loader is working (also warms loader by generating and caching required sub-loaders)
+		AssertEquals(
+			DeserializeJson(SerializeJson(data)),
+			DeserializeJson(SerializeJson(variables.loader.load(new test_cfcs.Bundle(), data))),
+			"start - loader failure (bundle doesn't match source data)"
+		);
+		// load a bunch of bundles nested 3 levels deep (i.e. bundle > widget[] > bundle[])
+		for ( var i = 0; i < loopCount; i++ ) {
+			var bundle = variables.loader.load(new test_cfcs.Bundle(), data);
+		}
+		// figure out how long it took
+		var elapsedTime = GetTickCount() - startTime;
+		// make sure the CFCs were being completely loaded (sanity check)
+		AssertEquals(
+			DeserializeJson(SerializeJson(data)),
+			DeserializeJson(SerializeJson(bundle)),
+			"finished - loader failure (bundle doesn't match source data)"
+		);
+		// "baseline" stats from 2019-01-23
+		var baseline = [
+			"elapsed ms": 150,
+			"loop count": 1000,
+			"avg load() ms": 0.15
+		];
+		// stats for the current run
+		var stats = [
+			"elapsed ms": elapsedTime,
+			"loop count": loopCount,
+			"avg load() ms": elapsedTime / loopCount
+		];
+		// display stats when run in debug
+		debug([
+			"baseline": baseline,
+			"current": stats
+		]);
+		// have we drastically exceeded previous benchmarks? (see var baseline above)
+		AssertTrue(
+			stats["elapsed ms"] < (3 * baseline["elapsed ms"]),
+			"load time has more than tripled since benchmark was established"
+		);
+	}
+
+	/**
 	* @hint "I test load (with generation)."
 	**/
 	public void function test_load_integration() {


### PR DESCRIPTION
When I fixed the circular dependency problem in issue #9 it added a race condition where loaders would be returned and used before their loaders cache was populated.

This fixes that. The loaders cache is still used. But, it takes a function call to allow it to lazy load.