### PR TITLE
Empty value fixes

### DIFF
--- a/generator.cfc
+++ b/generator.cfc
@@ -134,6 +134,13 @@ component {
 				}
 			';
 		}
+		if ( ListFindNoCase("boolean,date,guid,numeric,uuid", arguments.property.type) > 0 ) {
+			return '
+				if ( StructKeyExists(arguments.data, "#arguments.property.name#") && !IsNull(arguments.data["#arguments.property.name#"]) && IsValid("#arguments.property.type#", arguments.data["#arguments.property.name#"]) ) {
+					arguments.cfc.set#arguments.property.name#(arguments.data["#arguments.property.name#"]);
+				}
+			';
+		}
 		return '
 				if ( StructKeyExists(arguments.data, "#arguments.property.name#") && !IsNull(arguments.data["#arguments.property.name#"]) ) {
 					arguments.cfc.set#arguments.property.name#(arguments.data["#arguments.property.name#"]);

--- a/test_cfcs/Widget.cfc
+++ b/test_cfcs/Widget.cfc
@@ -1,6 +1,7 @@
 component accessors=true {
 	property name="id" type="numeric";
 	property name="isInBundles" type="array" item_type="test_cfcs.Bundle";
+	property name="isOnSpecial" type="boolean";
 	property name="name" type="string";
 	property name="options" type="array" item_type="test_cfcs.Option";
 }

--- a/test_generator.cfc
+++ b/test_generator.cfc
@@ -349,36 +349,6 @@ component extends="mxunit.framework.TestCase" {
 					}
 				'
 			},
-			"'boolean' setter": {
-				"property": {
-					"name": "booleanProp",
-					"type": "boolean",
-					"item_type": ""
-				},
-				"expect": '
-					if ( StructKeyExists(arguments.data, "booleanProp") && !IsNull(arguments.data["booleanProp"]) ) {
-						arguments.cfc.setbooleanProp(arguments.data["booleanProp"]);
-					}
-				'
-			},
-			"'component' (of item_type) setter": {
-				"property": {
-					"name": "optionProp",
-					"type": "component",
-					"item_type": "test_cfcs.Option"
-				},
-				"expect": '
-					if ( StructKeyExists(arguments.data, "optionProp") && !IsNull(arguments.data["optionProp"]) ) {
-						if ( IsStruct(arguments.data["optionProp"]) && !IsObject(arguments.data["optionProp"]) ) {
-							var vo = Duplicate(variables.vos["test_cfcs.Option"]);
-							getCfcLoader("test_cfcs.Option").load(cfc = vo, data = arguments.data["optionProp"]);
-							arguments.cfc.setoptionProp(vo);
-						} else {
-							arguments.cfc.setoptionProp(arguments.data["optionProp"]);
-						}
-					}
-				'
-			},
 			"'array' (of item_type) setter": {
 				"property": {
 					"name": "optionsProp",
@@ -402,6 +372,72 @@ component extends="mxunit.framework.TestCase" {
 					}
 				'
 			},
+			"'boolean' setter": {
+				"property": {
+					"name": "booleanProp",
+					"type": "boolean",
+					"item_type": ""
+				},
+				"expect": '
+					if ( StructKeyExists(arguments.data, "booleanProp") && !IsNull(arguments.data["booleanProp"]) && IsValid("boolean", arguments.data["booleanProp"]) ) {
+						arguments.cfc.setbooleanProp(arguments.data["booleanProp"]);
+					}
+				'
+			},
+			"'component' (of item_type) setter": {
+				"property": {
+					"name": "optionProp",
+					"type": "component",
+					"item_type": "test_cfcs.Option"
+				},
+				"expect": '
+					if ( StructKeyExists(arguments.data, "optionProp") && !IsNull(arguments.data["optionProp"]) ) {
+						if ( IsStruct(arguments.data["optionProp"]) && !IsObject(arguments.data["optionProp"]) ) {
+							var vo = Duplicate(variables.vos["test_cfcs.Option"]);
+							getCfcLoader("test_cfcs.Option").load(cfc = vo, data = arguments.data["optionProp"]);
+							arguments.cfc.setoptionProp(vo);
+						} else {
+							arguments.cfc.setoptionProp(arguments.data["optionProp"]);
+						}
+					}
+				'
+			},
+			"'date' setter": {
+				"property": {
+					"name": "dateProp",
+					"type": "date",
+					"item_type": ""
+				},
+				"expect": '
+					if ( StructKeyExists(arguments.data, "dateProp") && !IsNull(arguments.data["dateProp"]) && IsValid("date", arguments.data["dateProp"]) ) {
+						arguments.cfc.setdateProp(arguments.data["dateProp"]);
+					}
+				'
+			},
+			"'guid' setter": {
+				"property": {
+					"name": "guidProp",
+					"type": "guid",
+					"item_type": ""
+				},
+				"expect": '
+					if ( StructKeyExists(arguments.data, "guidProp") && !IsNull(arguments.data["guidProp"]) && IsValid("guid", arguments.data["guidProp"]) ) {
+						arguments.cfc.setguidProp(arguments.data["guidProp"]);
+					}
+				'
+			},
+			"'numeric' setter": {
+				"property": {
+					"name": "numericProp",
+					"type": "numeric",
+					"item_type": ""
+				},
+				"expect": '
+					if ( StructKeyExists(arguments.data, "numericProp") && !IsNull(arguments.data["numericProp"]) && IsValid("numeric", arguments.data["numericProp"]) ) {
+						arguments.cfc.setnumericProp(arguments.data["numericProp"]);
+					}
+				'
+			},
 			"string setter": {
 				"property": {
 					"name": "stringProp",
@@ -411,6 +447,18 @@ component extends="mxunit.framework.TestCase" {
 				"expect": '
 					if ( StructKeyExists(arguments.data, "stringProp") && !IsNull(arguments.data["stringProp"]) ) {
 						arguments.cfc.setstringProp(arguments.data["stringProp"]);
+					}
+				'
+			},
+			"'uuid' setter": {
+				"property": {
+					"name": "uuidProp",
+					"type": "uuid",
+					"item_type": ""
+				},
+				"expect": '
+					if ( StructKeyExists(arguments.data, "uuidProp") && !IsNull(arguments.data["uuidProp"]) && IsValid("uuid", arguments.data["uuidProp"]) ) {
+						arguments.cfc.setuuidProp(arguments.data["uuidProp"]);
 					}
 				'
 			}

--- a/test_loader.cfc
+++ b/test_loader.cfc
@@ -323,6 +323,7 @@ component extends="mxunit.framework.TestCase" {
 					"cfc": new test_cfcs.Widget(),
 					"data": {
 						"id": 1,
+						"isOnSpecial": "",
 						"name": "structs/arrays",
 						"options": [
 							{"id": 1, "name": "Option 1"},


### PR DESCRIPTION
Loading a boolean value from a struct like this `{"isTrue": ""}` would throw an error. Of course you shouldn't do that anyway. But, I felt like it was probably good for the library to check the types when it can before calling setters.

So, I updated it to check types for certain "simple" types.