### PR TITLE
Skip metadata

### DIFF
--- a/generator.cfc
+++ b/generator.cfc
@@ -24,7 +24,10 @@ component {
 
 			private component function getCfcLoader(required string cfcName) {
 				if ( !StructKeyExists(variables.loaders, arguments.cfcName) ) {
-					variables.loaders[arguments.cfcName] = variables.parentLoader.getCfcLoader(variables.vos[arguments.cfcName]);
+					variables.loaders[arguments.cfcName] = variables.parentLoader.getCfcLoader(
+						cfc = variables.vos[arguments.cfcName],
+						cfcName = arguments.cfcName
+					);
 				}
 				return variables.loaders[arguments.cfcName];
 			}

--- a/generator.cfc
+++ b/generator.cfc
@@ -176,9 +176,9 @@ component {
 				// add the base of the original CFC to "extends"
 				extends = ReReplace(arguments.cfcName, ListLast(arguments.cfcName, ".") & "$", "") & extends;
 			}
-			var extendedCFc = getRecursiveCfcCode(cfcName = extends);
+			var extendedCfc = getRecursiveCfcCode(cfcName = extends);
 		}
-		return code & extendedCFc;
+		return code & extendedCfc;
 	}
 
 	/**

--- a/generator.cfc
+++ b/generator.cfc
@@ -42,6 +42,28 @@ component {
 	}
 
 	/**
+	* @hint returns contents of CFC file (and every CFC in the extends tree)
+	**/
+	public string function getRecursiveCfcCode(required string cfcName) {
+		var filePath = "/" & Replace(arguments.cfcName, ".", "/", "all") & ".cfc";
+		var code = Trim(FileRead(ExpandPath(filePath)));
+		var extendsRegex = ".*[\s]+extends[\s]*=[\s]*['""]([^'""]+)['""].*";
+		var extendedCfc = "";
+		if ( RefindNoCase(extendsRegex, code) > 0 ) {
+			// cfc passed in extends another CFC.
+			// So, let's get it's contents.
+			var extends = ReReplaceNoCase(code, extendsRegex, "\1");
+			if ( ListLen(extends, ".") == 1 && ListLen(arguments.cfcName, ".") > 1 ) {
+				// special case of a CFC extending a peer (in same directory)
+				// add the base of the original CFC to "extends"
+				extends = ReReplace(arguments.cfcName, ListLast(arguments.cfcName, ".") & "$", "") & extends;
+			}
+			var extendedCFc = getRecursiveCfcCode(cfcName = extends);
+		}
+		return code & extendedCFc;
+	}
+
+	/**
 	* @hint generates code for the load()
 	**/
 	public string function getLoadMethod(required array properties) {

--- a/generator.cfc
+++ b/generator.cfc
@@ -165,12 +165,13 @@ component {
 	public string function getRecursiveCfcCode(required string cfcName) {
 		var filePath = "/" & Replace(arguments.cfcName, ".", "/", "all") & ".cfc";
 		var code = Trim(FileRead(ExpandPath(filePath)));
-		var extendsRegex = ".*[\s]+extends[\s]*=[\s]*['""]([^'""]+)['""].*";
+		var extendsRegex = "[\s]+extends[\s]*=[\s]*['""]([^'""]+)['""]";
 		var extendedCfc = "";
 		if ( RefindNoCase(extendsRegex, code) > 0 ) {
 			// cfc passed in extends another CFC.
 			// So, let's get it's contents.
-			var extends = ReReplaceNoCase(code, extendsRegex, "\1");
+			var matches = ReFindNoCase(extendsRegex, code, 1, true, "one");
+			var extends = matches.match[2];
 			if ( ListLen(extends, ".") == 1 && ListLen(arguments.cfcName, ".") > 1 ) {
 				// special case of a CFC extending a peer (in same directory)
 				// add the base of the original CFC to "extends"

--- a/loader.cfc
+++ b/loader.cfc
@@ -10,6 +10,13 @@ component accessors=true {
 	}
 
 	/**
+	* @hint Clears loader cache (for testing)
+	**/
+	public void function clearLoaderCache() {
+		variables.loaderCache = {};
+	}
+
+	/**
 	* @hint given a string, returns a string mimicking (cffile action="write" fixnewline="yes")
 	* @see  https://www.raymondcamden.com/2014/02/10/Mimicking-fixNewLine-in-ColdFusion-Script
 	**/
@@ -25,9 +32,11 @@ component accessors=true {
 	/**
 	* @hint returns a specific loader given a cfc
 	**/
-	public component function getCfcLoader(required component cfc) {
-		var cfcName = getCfcName(cfc = arguments.cfc);
-		if ( !StructKeyExists(variables.loaderCache, cfcName) ) {
+	public component function getCfcLoader(required component cfc, string cfcName) {
+		if ( !StructKeyExists(arguments, "cfcName") || Len(arguments.cfcName) == 0 ) {
+			arguments.cfcName = getCfcName(cfc = arguments.cfc);
+		}
+		if ( !StructKeyExists(variables.loaderCache, arguments.cfcName) ) {
 			var loaderName = getCfcLoaderName(cfc = arguments.cfc);
 			if ( !loaderExists(cfcName = loaderName) ) {
 				writeLoader(
@@ -35,9 +44,9 @@ component accessors=true {
 					code = fixNewLine(getGenerator().generate(cfc = arguments.cfc))
 				);
 			}
-			variables.loaderCache[cfcName] = CreateObject("component", loaderName).init(loader = this);
+			variables.loaderCache[arguments.cfcName] = CreateObject("component", loaderName).init(loader = this);
 		}
-		return variables.loaderCache[cfcName];
+		return variables.loaderCache[arguments.cfcName];
 	}
 
 	/**

--- a/loader.cfc
+++ b/loader.cfc
@@ -87,12 +87,13 @@ component accessors=true {
 	**/
 	public component function load(
 		required component cfc,
-		required any data = {}
+		required any data = {},
+		string cfcName = ""
 	) {
 		if ( !IsStruct(arguments.data) ) {
 			arguments.data = DeserializeJson(arguments.data);
 		}
-		getCfcLoader(cfc = arguments.cfc).load(
+		getCfcLoader(cfc = arguments.cfc, cfcName = arguments.cfcName).load(
 			cfc = arguments.cfc,
 			data = arguments.data
 		);

--- a/loader.cfc
+++ b/loader.cfc
@@ -37,7 +37,7 @@ component accessors=true {
 			arguments.cfcName = getCfcName(cfc = arguments.cfc);
 		}
 		if ( !StructKeyExists(variables.loaderCache, arguments.cfcName) ) {
-			var loaderName = getCfcLoaderName(cfc = arguments.cfc);
+			var loaderName = getCfcLoaderName(cfc = arguments.cfc, cfcName = arguments.cfcName);
 			if ( !loaderExists(cfcName = loaderName) ) {
 				writeLoader(
 					cfcName = loaderName,

--- a/loader.cfc
+++ b/loader.cfc
@@ -52,22 +52,26 @@ component accessors=true {
 	/**
 	* @hint returns a loader name given a cfc (specific to the CFC and its current metadata)
 	**/
-	private string function getCfcLoaderName(required component cfc) {
-		var cfcName = getCfcName(cfc = arguments.cfc);
+	private string function getCfcLoaderName(required component cfc, string cfcName) {
+		if ( StructKeyExists(arguments, "cfcName") && Len(arguments.cfcName) > 0 ) {
+			var loaderName = arguments.cfcName;
+		} else {
+			var loaderName = getCfcName(cfc = arguments.cfc);
+		}
 		// We're going to replace the dots (which represent directories in CFC names) with underscore.
 		// But, some CFCs already have an underscore in the name.
 		// And we could get a naming collision with two cfcs like the following:
 		// 	* com.foo.bar_baz > com_foo_bar_baz
 		// 	* com.foo.bar.baz > com_foo_bar_baz
 		// So, I'm going to double up underscores in names before replacing the dots.
-		cfcName = Replace(cfcName, "_", "__", "all");
+		loaderName = Replace(loaderName, "_", "__", "all");
 		// Replace dots with underscores (to keep all loaders in one directory).
-		cfcName = Replace(cfcName, ".", "_", "all");
+		loaderName = Replace(loaderName, ".", "_", "all");
 		// Prepend LoadersPath to fully qualify CFC name.
-		cfcName = getLoadersPath() & '.' & cfcName;
+		loaderName = getLoadersPath() & '.' & loaderName;
 		// Suffix cfc path with hash so that we know it's the right "version" for the CFC.
-		cfcName &= "_" & getGenerator().getSignature(cfc = arguments.cfc);
-		return cfcName;
+		loaderName &= "_" & getGenerator().getSignature(cfc = arguments.cfc);
+		return loaderName;
 	}
 
 	/**

--- a/loader.cfc
+++ b/loader.cfc
@@ -57,6 +57,7 @@ component accessors=true {
 			var loaderName = arguments.cfcName;
 		} else {
 			var loaderName = getCfcName(cfc = arguments.cfc);
+			arguments.cfcName = loaderName;
 		}
 		// We're going to replace the dots (which represent directories in CFC names) with underscore.
 		// But, some CFCs already have an underscore in the name.
@@ -70,7 +71,7 @@ component accessors=true {
 		// Prepend LoadersPath to fully qualify CFC name.
 		loaderName = getLoadersPath() & '.' & loaderName;
 		// Suffix cfc path with hash so that we know it's the right "version" for the CFC.
-		loaderName &= "_" & getGenerator().getSignature(cfc = arguments.cfc);
+		loaderName &= "_" & getGenerator().getSignature(cfcName = arguments.cfcName);
 		return loaderName;
 	}
 

--- a/test_generator.cfc
+++ b/test_generator.cfc
@@ -69,7 +69,10 @@ component extends="mxunit.framework.TestCase" {
 
 							private component function getCfcLoader(required string cfcName) {
 								if ( !StructKeyExists(variables.loaders, arguments.cfcName) ) {
-									variables.loaders[arguments.cfcName] = variables.parentLoader.getCfcLoader(variables.vos[arguments.cfcName]);
+									variables.loaders[arguments.cfcName] = variables.parentLoader.getCfcLoader(
+										cfc = variables.vos[arguments.cfcName],
+										cfcName = arguments.cfcName
+									);
 								}
 								return variables.loaders[arguments.cfcName];
 							}
@@ -133,7 +136,10 @@ component extends="mxunit.framework.TestCase" {
 
 							private component function getCfcLoader(required string cfcName) {
 								if ( !StructKeyExists(variables.loaders, arguments.cfcName) ) {
-									variables.loaders[arguments.cfcName] = variables.parentLoader.getCfcLoader(variables.vos[arguments.cfcName]);
+									variables.loaders[arguments.cfcName] = variables.parentLoader.getCfcLoader(
+										cfc = variables.vos[arguments.cfcName],
+										cfcName = arguments.cfcName
+									);
 								}
 								return variables.loaders[arguments.cfcName];
 							}

--- a/test_generator.cfc
+++ b/test_generator.cfc
@@ -188,6 +188,77 @@ component extends="mxunit.framework.TestCase" {
 	}
 
 	/**
+	* @hint "I test getRecursiveCfcCode."
+	**/
+	public void function test_getRecursiveCfcCode() {
+		var tests = [
+			"no extends": {
+				args: {
+					cfcName: "test_cfcs.ExtendsBase"
+				},
+				expect: {
+					result: '
+						component accessors="true" {
+							property name="base1" type="string";
+							property name="base2" type="string";
+						}
+					'
+				}
+			},
+			"extends one level": {
+				args: {
+					cfcName: "test_cfcs.Extends1"
+				},
+				expect: {
+					result: '
+						component accessors="true" extends="ExtendsBase" {
+							property name="extends1" type="string";
+						}
+						component accessors="true" {
+							property name="base1" type="string";
+							property name="base2" type="string";
+						}
+					'
+				}
+			},
+			"extends multiple levels": {
+				args: {
+					cfcName: "test_cfcs.Extends2"
+				},
+				expect: {
+					result: '
+						component accessors="true" extends="Extends1" {
+							property name="extends2" type="string";
+						}
+						component accessors="true" extends="ExtendsBase" {
+							property name="extends1" type="string";
+						}
+						component accessors="true" {
+							property name="base1" type="string";
+							property name="base2" type="string";
+						}
+					'
+				}
+			}
+		];
+		for ( var name in tests ) {
+			var test = tests[name];
+			try {
+				var result = variables.generator.getRecursiveCfcCode(cfcName = test.args.cfcName);
+			} catch (any e) {
+				debug(e);
+				fail("#name# - unexpected error (#e.message#). run w/ debug for details.");
+			}
+			var trimWhiteSpace = "(?m)\s+";
+			AssertEquals(
+				ReReplace("<pre>" & Trim(test.expect.result), trimWhiteSpace, "", "all") & "</pre>",
+				ReReplace("<pre>" & Trim(result), trimWhiteSpace, "", "all") & "</pre>",
+				"#name# - result doesn't match expected"
+			);
+		}
+	}
+
+	/**
 	* @hint "I test getLoadMethod."
 	**/
 	public void function test_getLoadMethod() {

--- a/test_generator.cfc
+++ b/test_generator.cfc
@@ -559,32 +559,32 @@ component extends="mxunit.framework.TestCase" {
 	* @hint "I test getSignature."
 	**/
 	public void function test_getSignature() {
-		MakePublic(variables.generator, "getProperties");
-		InjectMethod(variables.generator, this, "getPropertiesMock", "getProperties");
+		MakePublic(variables.generator, "getRecursiveCfcCode");
+		InjectMethod(variables.generator, this, "getRecursiveCfcCodeMock", "getRecursiveCfcCode");
 		// If the cfc (or any it extends) changes, we would need to generate a new loader.
 		// We would also need to generate a new loader if the generator itself changed.
 		// So, the signature of a generated loader is the hash of:
-		// 	the data container CFC's metadata
-		// 	+ the actual code of the generator
+		// 	the code of the CFC (and all it extends)
+		// 	+ the code of the generator
 		var generatorCode = FileRead(GetMetaData(variables.generator).Path);
 		var tests = [
 			{
-				"cfc": "test_cfcs.Bundle",
-				"expect": Hash(SerializeJson(["test_cfcs.Bundle"]) & generatorCode)
+				"cfcName": "test_cfcs.Bundle",
+				"expect": Hash("test_cfcs.Bundle" & generatorCode)
 			},
 			{
-				"cfc": "test_cfcs.Option",
-				"expect": Hash(SerializeJson(["test_cfcs.Option"]) & generatorCode)
+				"cfcName": "test_cfcs.Option",
+				"expect": Hash("test_cfcs.Option" & generatorCode)
 			}
 		];
 		for ( var test in tests ) {
 			// set up mocks
-			variables.generator["getProperties_Args"] = [];
-			variables.generator["getProperties_Mock"] = [test.cfc];
+			variables.generator["getRecursiveCfcCode_Args"] = [];
+			variables.generator["getRecursiveCfcCode_Mock"] = test.cfcName;
 			// call method under test
-			var result = variables.generator.getSignature(cfc = CreateObject("component", test.cfc));
+			var result = variables.generator.getSignature(cfcName = test.cfcName);
 			// check assertions
-			AssertEquals(test.expect, result, test.cfc & " signature doesn't match");
+			AssertEquals(test.expect, result, test.cfcName & " signature doesn't match");
 		}
 	}
 
@@ -658,6 +658,11 @@ component extends="mxunit.framework.TestCase" {
 	private string function getPropertyCodeMock(required struct property) {
 		ArrayAppend(this["getPropertyCode_Args"], arguments);
 		return this["getPropertyCode_Mock"];
+	}
+
+	private string function getRecursiveCfcCodeMock(required string cfcName) {
+		ArrayAppend(this["getRecursiveCfcCode_Args"], arguments);
+		return this["getRecursiveCfcCode_Mock"];
 	}
 
 	private string function getVoCacheCodeMock(required array properties) {

--- a/test_loader.cfc
+++ b/test_loader.cfc
@@ -221,6 +221,25 @@ component extends="mxunit.framework.TestCase" {
 					},
 					"result": "test_loaders.foo_bar__baz_qux_signature2" // double underscore to disambiguate directory dots being replaced by _
 				}
+			},
+			"test three (use cfcName)": {
+				"args": {
+					"cfc": new test_cfcs.Option().setId(2),
+					"cfcName": "test_cfcs.Option"
+				},
+				"mocks": {
+					"getCfcName": "N/A",
+					"generator.getSignature": "signature2"
+				},
+				"expect": {
+					"calls": {
+						"getCfcName": [], // arg cfcName skips getCfcName(), thus skipping GetMetaData(cfc).name
+						"generator.getSignature": [
+							{"cfc": SerializeJson(new test_cfcs.Option().setId(2))}
+						]
+					},
+					"result": "test_loaders.test__cfcs_option_signature2" // double underscore to disambiguate directory dots being replaced by _
+				}
 			}
 		];
 		MakePublic(variables.loader, "getCfcName");
@@ -242,7 +261,7 @@ component extends="mxunit.framework.TestCase" {
 			};
 			variables.loader.setGenerator(mockGenerator);
 			// call method under test
-			var result = variables.loader.getCfcLoaderName(cfc = test.args.cfc);
+			var result = variables.loader.getCfcLoaderName(argumentCollection = test.args);
 			// check assertions
 			calls["getCfcName"] = variables.loader["getCfcName_Args"];
 			AssertEquals(test.expect.calls, calls, "#name# - calls don't match expected");

--- a/test_loader.cfc
+++ b/test_loader.cfc
@@ -205,7 +205,7 @@ component extends="mxunit.framework.TestCase" {
 							{"cfc": SerializeJson(new test_cfcs.Bundle().setId(1))}
 						],
 						"generator.getSignature": [
-							{"cfc": SerializeJson(new test_cfcs.Bundle().setId(1))}
+							{"cfcName": "foo.bar.baz"}
 						]
 					},
 					"result": "test_loaders.foo_bar_baz_signature1"
@@ -225,7 +225,7 @@ component extends="mxunit.framework.TestCase" {
 							{"cfc": SerializeJson(new test_cfcs.Option().setId(2))}
 						],
 						"generator.getSignature": [
-							{"cfc": SerializeJson(new test_cfcs.Option().setId(2))}
+							{"cfcName": "foo.bar_baz.qux"}
 						]
 					},
 					"result": "test_loaders.foo_bar__baz_qux_signature2" // double underscore to disambiguate directory dots being replaced by _
@@ -244,7 +244,7 @@ component extends="mxunit.framework.TestCase" {
 					"calls": {
 						"getCfcName": [], // arg cfcName skips getCfcName(), thus skipping GetMetaData(cfc).name
 						"generator.getSignature": [
-							{"cfc": SerializeJson(new test_cfcs.Option().setId(2))}
+							{"cfcName": "test_cfcs.Option"}
 						]
 					},
 					"result": "test_loaders.test__cfcs_option_signature2" // double underscore to disambiguate directory dots being replaced by _
@@ -263,8 +263,8 @@ component extends="mxunit.framework.TestCase" {
 			variables.loader["getCfcName_Mock"] = test.mocks.getCfcName;
 			variables.loader["getCfcName_Args"] = [];
 			var mockGenerator = new test_cfcs.Blank();
-			mockGenerator.getSignature = function(required component cfc) {
-				ArrayAppend(calls["generator.getSignature"], {"cfc": SerializeJson(arguments.cfc)});
+			mockGenerator.getSignature = function(required string cfcName) {
+				ArrayAppend(calls["generator.getSignature"], {"cfcName": arguments.cfcName});
 				var mocks = Duplicate(test.mocks);
 				return mocks["generator.getSignature"];
 			};

--- a/test_loader.cfc
+++ b/test_loader.cfc
@@ -56,7 +56,10 @@ component extends="mxunit.framework.TestCase" {
 					"calls": {
 						"getCfcName": [], // arg cfcName skips getCfcName(), thus skipping GetMetaData(cfc).name
 						"getCfcLoaderName": [
-							{"cfc": SerializeJson(new test_cfcs.Bundle().setId(1))}
+							{
+								"cfc": SerializeJson(new test_cfcs.Bundle().setId(1)),
+								"cfcName": "test_cfcs.Bundle"
+							}
 						],
 						"loaderExists": [
 							{"cfcName": "test_loaders.test_cfcs_Bundle"}
@@ -84,7 +87,10 @@ component extends="mxunit.framework.TestCase" {
 							{"cfc": SerializeJson(new test_cfcs.Bundle().setId(1))}
 						],
 						"getCfcLoaderName": [
-							{"cfc": SerializeJson(new test_cfcs.Bundle().setId(1))}
+							{
+								"cfc": SerializeJson(new test_cfcs.Bundle().setId(1)),
+								"cfcName": "test_cfcs.Bundle"
+							}
 						],
 						"loaderExists": [
 							{"cfcName": "test_loaders.test_cfcs_Bundle"}
@@ -112,7 +118,10 @@ component extends="mxunit.framework.TestCase" {
 							{"cfc": SerializeJson(new test_cfcs.Option().setId(2))}
 						],
 						"getCfcLoaderName": [
-							{"cfc": SerializeJson(new test_cfcs.Option().setId(2))}
+							{
+								"cfc": SerializeJson(new test_cfcs.Option().setId(2)),
+								"cfcName": "test_cfcs.Option"
+							}
 						],
 						"loaderExists": [
 							{"cfcName": "test_loaders.test_cfcs_Option"}
@@ -594,8 +603,13 @@ component extends="mxunit.framework.TestCase" {
 		return this["getCfcLoader_Mock"];
 	}
 
-	private string function getCfcLoaderNameMock(required component cfc) {
-		ArrayAppend(this["getCfcLoaderName_Args"], {"cfc": SerializeJson(arguments.cfc)});
+	private string function getCfcLoaderNameMock(required component cfc, string cfcName) {
+		var args = {};
+		if ( StructKeyExists(arguments, "cfcName") && Len(arguments.cfcName) > 0 ) {
+			args["cfcName"] = arguments.cfcName;
+		}
+		args.cfc = SerializeJson(arguments.cfc);
+		ArrayAppend(this["getCfcLoaderName_Args"], args);
 		return this["getCfcLoaderName_Mock"];
 	}
 


### PR DESCRIPTION
This is all because of an Adobe bug. 

See: https://tracker.adobe.com/#/view/CF-4206904

Basically, I'm trying to allow an optional way to skip the loader having to call GetMetaData().

Here is a comparison of calling loader both ways:

```
// Original
getLoader().load(
	cfc = new com.dealerpeak.IdName(),
	data = {id: 1, name: "Foo"}
);

// Optional update
getLoader().load(
	cfcName = "com.dealerpeak.IdName",
	cfc = new com.dealerpeak.IdName(),
	data = {id: 1, name: "Foo"}
);
```

Unfortunatly, this probably only gets us half way there. Whenever the loader is reloaded, it starts caching loaders again. And it uses GetMetaData() to calculate a current "signature" of the properties/functions in the CFC. This is so that if the CFC (or one it extends) changes structure, a new loader will be generated. So, there is really no way around this.